### PR TITLE
refactor: migrate nate.rip to site.standard schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1654,7 +1654,6 @@
       "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-5.1.1.tgz",
       "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
         "debug": "^4.4.1",
@@ -1762,7 +1761,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1899,7 +1897,6 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-5.17.1.tgz",
       "integrity": "sha512-oD3tlxTaVWGq/Wfbqk6gxzVRz98xa/rYlpe+gU2jXJMSD01k6sEDL01ZlT8mVSYB/rMgnvIOfiQQ3BbLdN237A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.13.0",
         "@astrojs/internal-helpers": "0.7.5",
@@ -4571,7 +4568,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
       "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -4818,7 +4814,6 @@
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.50.0.tgz",
       "integrity": "sha512-FR9kTLmX5i0oyeQ5j/+w8DuagIkQ7MWMuPpPVioW2zx9Dw77q+1ufLzF1IqNtcTXPRnIIio4PlasliVn43OnbQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -4973,7 +4968,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -4995,7 +4989,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5012,7 +5005,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5029,7 +5021,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5046,7 +5037,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5063,7 +5053,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5080,7 +5069,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5097,7 +5085,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5114,7 +5101,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5131,7 +5117,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5148,7 +5133,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5165,7 +5149,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5182,7 +5165,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5199,7 +5181,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5216,7 +5197,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5233,7 +5213,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5250,7 +5229,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5267,7 +5245,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5284,7 +5261,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5301,7 +5277,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5318,7 +5293,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5335,7 +5309,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5352,7 +5325,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5369,7 +5341,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5386,7 +5357,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5403,7 +5373,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5420,7 +5389,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5489,7 +5457,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5829,7 +5796,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -6034,7 +6000,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/scripts/lexicons/site.standard.document.json
+++ b/scripts/lexicons/site.standard.document.json
@@ -1,0 +1,101 @@
+{
+  "lexicon": 1,
+  "id": "site.standard.document",
+  "defs": {
+    "main": {
+      "type": "record",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["site", "title", "publishedAt"],
+        "properties": {
+          "site": {
+            "type": "string",
+            "maxLength": 2048,
+            "description": "AT-URI of the publication record or base URL for loose documents."
+          },
+          "title": {
+            "type": "string",
+            "maxLength": 5000,
+            "maxGraphemes": 500,
+            "description": "Title of the document."
+          },
+          "publishedAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Timestamp of the document's publish time."
+          },
+          "path": {
+            "type": "string",
+            "maxLength": 2048,
+            "description": "Path to combine with site URL (e.g., /f/42). Should start with /."
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 30000,
+            "maxGraphemes": 3000,
+            "description": "Brief description or excerpt from the document."
+          },
+          "coverImage": {
+            "type": "blob",
+            "accept": ["image/png", "image/jpeg", "image/gif", "image/webp"],
+            "maxSize": 1000000,
+            "description": "Image used for thumbnail or cover."
+          },
+          "textContent": {
+            "type": "string",
+            "maxLength": 500000,
+            "description": "Plaintext or markdown content of the document."
+          },
+          "tags": {
+            "type": "array",
+            "maxLength": 8,
+            "items": {
+              "type": "string",
+              "maxLength": 1280,
+              "maxGraphemes": 128
+            },
+            "description": "Tags to categorize the document."
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Timestamp of the document's last edit."
+          },
+          "bskyPostRef": {
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "Reference to a Bluesky post for comments."
+          },
+
+          "fragmentId": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Extension: nate.rip fragment ID for URL generation."
+          },
+          "fragmentType": {
+            "type": "string",
+            "enum": ["post", "shot", "list", "link"],
+            "description": "Extension: nate.rip content type."
+          },
+          "images": {
+            "type": "array",
+            "maxLength": 20,
+            "items": {
+              "type": "blob",
+              "accept": ["image/png", "image/jpeg", "image/gif", "image/webp", "image/svg+xml", "video/mp4"],
+              "maxSize": 50000000
+            },
+            "description": "Extension: Multiple images for shot galleries."
+          },
+          "externalUrl": {
+            "type": "string",
+            "format": "uri",
+            "maxLength": 2048,
+            "description": "Extension: External URL for link-type fragments."
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/lexicons/site.standard.document.json
+++ b/scripts/lexicons/site.standard.document.json
@@ -11,8 +11,8 @@
         "properties": {
           "site": {
             "type": "string",
-            "maxLength": 2048,
-            "description": "AT-URI of the publication record or base URL for loose documents."
+            "format": "uri",
+            "description": "Points to a publication record (at://) or a publication url (https://) for loose documents. Avoid trailing slashes."
           },
           "title": {
             "type": "string",
@@ -27,35 +27,38 @@
           },
           "path": {
             "type": "string",
-            "maxLength": 2048,
-            "description": "Path to combine with site URL (e.g., /f/42). Should start with /."
+            "description": "Combine with site or publication url to construct a canonical URL to the document. Prepend with a leading slash."
           },
           "description": {
             "type": "string",
             "maxLength": 30000,
             "maxGraphemes": 3000,
-            "description": "Brief description or excerpt from the document."
+            "description": "A brief description or excerpt from the document."
           },
           "coverImage": {
             "type": "blob",
-            "accept": ["image/png", "image/jpeg", "image/gif", "image/webp"],
+            "accept": ["image/*"],
             "maxSize": 1000000,
-            "description": "Image used for thumbnail or cover."
+            "description": "Image used for thumbnail or cover image. Less than 1MB in size."
+          },
+          "content": {
+            "type": "union",
+            "refs": [],
+            "closed": false,
+            "description": "Open union used to define the record's content. Each entry must specify a $type and may be extended with other lexicons to support additional content formats."
           },
           "textContent": {
             "type": "string",
-            "maxLength": 500000,
-            "description": "Plaintext or markdown content of the document."
+            "description": "Plaintext representation of the document's contents. Should not contain markdown or other formatting."
           },
           "tags": {
             "type": "array",
-            "maxLength": 8,
             "items": {
               "type": "string",
               "maxLength": 1280,
               "maxGraphemes": 128
             },
-            "description": "Tags to categorize the document."
+            "description": "Array of strings used to tag or categorize the document. Avoid prepending tags with hashtags."
           },
           "updatedAt": {
             "type": "string",
@@ -65,7 +68,7 @@
           "bskyPostRef": {
             "type": "ref",
             "ref": "com.atproto.repo.strongRef",
-            "description": "Reference to a Bluesky post for comments."
+            "description": "Strong reference to a Bluesky post. Useful to keep track of comments off-platform."
           },
 
           "fragmentId": {

--- a/scripts/lexicons/site.standard.publication.json
+++ b/scripts/lexicons/site.standard.publication.json
@@ -4,7 +4,7 @@
   "defs": {
     "main": {
       "type": "record",
-      "key": "any",
+      "key": "tid",
       "record": {
         "type": "object",
         "required": ["url", "name"],
@@ -12,8 +12,7 @@
           "url": {
             "type": "string",
             "format": "uri",
-            "maxLength": 2048,
-            "description": "Base URL for the publication (e.g., https://nate.rip). Avoid trailing slashes."
+            "description": "Base publication url (ex: https://nate.rip). The canonical document URL is formed by combining this value with the document path."
           },
           "name": {
             "type": "string",
@@ -23,7 +22,7 @@
           },
           "icon": {
             "type": "blob",
-            "accept": ["image/png", "image/jpeg", "image/gif", "image/webp"],
+            "accept": ["image/*"],
             "maxSize": 1000000,
             "description": "Square image to identify the publication. Should be at least 256x256."
           },
@@ -36,19 +35,27 @@
           "basicTheme": {
             "type": "ref",
             "ref": "site.standard.theme.basic",
-            "description": "Simplified theme for tools and apps."
+            "description": "Simplified publication theme for tools and apps to utilize when displaying content."
           },
           "preferences": {
-            "type": "object",
-            "properties": {
-              "showInDiscover": {
-                "type": "boolean",
-                "description": "Whether the publication should appear in discovery feeds."
-              }
-            }
+            "type": "ref",
+            "ref": "#preferences",
+            "description": "Object containing platform specific preferences."
           }
         }
-      }
+      },
+      "description": "A publication record representing a blog, website, or content platform."
+    },
+    "preferences": {
+      "type": "object",
+      "properties": {
+        "showInDiscover": {
+          "type": "boolean",
+          "default": true,
+          "description": "Boolean which decides whether the publication should appear in discovery feeds."
+        }
+      },
+      "description": "Platform-specific preferences for the publication."
     }
   }
 }

--- a/scripts/lexicons/site.standard.publication.json
+++ b/scripts/lexicons/site.standard.publication.json
@@ -1,0 +1,54 @@
+{
+  "lexicon": 1,
+  "id": "site.standard.publication",
+  "defs": {
+    "main": {
+      "type": "record",
+      "key": "any",
+      "record": {
+        "type": "object",
+        "required": ["url", "name"],
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "maxLength": 2048,
+            "description": "Base URL for the publication (e.g., https://nate.rip). Avoid trailing slashes."
+          },
+          "name": {
+            "type": "string",
+            "maxLength": 5000,
+            "maxGraphemes": 500,
+            "description": "Name of the publication."
+          },
+          "icon": {
+            "type": "blob",
+            "accept": ["image/png", "image/jpeg", "image/gif", "image/webp"],
+            "maxSize": 1000000,
+            "description": "Square image to identify the publication. Should be at least 256x256."
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 30000,
+            "maxGraphemes": 3000,
+            "description": "Brief description of the publication."
+          },
+          "basicTheme": {
+            "type": "ref",
+            "ref": "site.standard.theme.basic",
+            "description": "Simplified theme for tools and apps."
+          },
+          "preferences": {
+            "type": "object",
+            "properties": {
+              "showInDiscover": {
+                "type": "boolean",
+                "description": "Whether the publication should appear in discovery feeds."
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/lexicons/site.standard.theme.basic.json
+++ b/scripts/lexicons/site.standard.theme.basic.json
@@ -1,0 +1,33 @@
+{
+  "lexicon": 1,
+  "id": "site.standard.theme.basic",
+  "defs": {
+    "main": {
+      "type": "object",
+      "required": ["background", "foreground", "accent", "accentForeground"],
+      "properties": {
+        "background": {
+          "type": "union",
+          "refs": ["site.standard.theme.color#rgb"],
+          "description": "Color used for content background."
+        },
+        "foreground": {
+          "type": "union",
+          "refs": ["site.standard.theme.color#rgb"],
+          "description": "Color used for content text."
+        },
+        "accent": {
+          "type": "union",
+          "refs": ["site.standard.theme.color#rgb"],
+          "description": "Color used for links and button backgrounds."
+        },
+        "accentForeground": {
+          "type": "union",
+          "refs": ["site.standard.theme.color#rgb"],
+          "description": "Color used for button text."
+        }
+      },
+      "description": "A simplified theme definition for publications."
+    }
+  }
+}

--- a/scripts/lexicons/site.standard.theme.color.json
+++ b/scripts/lexicons/site.standard.theme.color.json
@@ -1,0 +1,53 @@
+{
+  "lexicon": 1,
+  "id": "site.standard.theme.color",
+  "defs": {
+    "rgb": {
+      "type": "object",
+      "required": ["r", "g", "b"],
+      "properties": {
+        "r": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "g": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "b": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        }
+      }
+    },
+    "rgba": {
+      "type": "object",
+      "required": ["r", "g", "b", "a"],
+      "properties": {
+        "r": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "g": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "b": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "a": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
+    }
+  }
+}

--- a/scripts/lib/markdown.ts
+++ b/scripts/lib/markdown.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared markdown utilities for upload scripts.
+ */
+
+/**
+ * Strip markdown formatting to produce plaintext for textContent field.
+ * The site.standard spec says textContent "Should not contain markdown or other formatting."
+ */
+export function stripMarkdown(md: string): string {
+  return md
+    // Remove images
+    .replace(/!\[([^\]]*)\]\([^)]+\)/g, '$1')
+    // Remove links, keep text
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    // Remove bold/italic
+    .replace(/(\*\*|__)(.*?)\1/g, '$2')
+    .replace(/(\*|_)(.*?)\1/g, '$2')
+    // Remove inline code
+    .replace(/`([^`]+)`/g, '$1')
+    // Remove code blocks
+    .replace(/```[\s\S]*?```/g, '')
+    // Remove headers
+    .replace(/^#{1,6}\s+/gm, '')
+    // Remove blockquotes
+    .replace(/^>\s+/gm, '')
+    // Remove horizontal rules
+    .replace(/^[-*_]{3,}$/gm, '')
+    // Remove list markers
+    .replace(/^[\s]*[-*+]\s+/gm, '')
+    .replace(/^[\s]*\d+\.\s+/gm, '')
+    // Collapse multiple newlines
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+/**
+ * Create a content union entry for markdown content.
+ * Uses a custom type since site.standard.document has an open content union.
+ */
+export function markdownContent(text: string): { $type: string; text: string } {
+  return {
+    $type: 'rip.nate.content.markdown',
+    text,
+  };
+}

--- a/scripts/migrate-to-standard.ts
+++ b/scripts/migrate-to-standard.ts
@@ -1,0 +1,193 @@
+/**
+ * Migrate existing rip.nate.* records to site.standard.document format.
+ * Usage: ATP_PASSWORD=... npx tsx scripts/migrate-to-standard.ts [--dry-run] [--delete-old]
+ *
+ * This script:
+ * 1. Reads all existing rip.nate.{post,shot,list,link} records
+ * 2. Creates corresponding site.standard.document records
+ * 3. Optionally deletes old records (--delete-old)
+ */
+import { AtpAgent } from '@atproto/api';
+
+const DID = 'did:plc:5dnwnjydruv7wmbi33xchkr6';
+const HANDLE = process.env.ATP_HANDLE || 'nate.rip';
+const PASSWORD = process.env.ATP_PASSWORD;
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const DELETE_OLD = process.argv.includes('--delete-old');
+
+if (!PASSWORD && !DRY_RUN) {
+  console.error('Set ATP_PASSWORD env var');
+  process.exit(1);
+}
+
+const PUBLICATION_URI = `at://${DID}/site.standard.publication/self`;
+const PDS = 'https://morel.us-east.host.bsky.network';
+
+const OLD_COLLECTIONS = [
+  'rip.nate.post',
+  'rip.nate.shot',
+  'rip.nate.list',
+  'rip.nate.link',
+] as const;
+
+type OldCollection = typeof OLD_COLLECTIONS[number];
+
+const TYPE_MAP: Record<OldCollection, string> = {
+  'rip.nate.post': 'post',
+  'rip.nate.shot': 'shot',
+  'rip.nate.list': 'list',
+  'rip.nate.link': 'link',
+};
+
+async function listRecords(collection: string): Promise<any[]> {
+  const records: any[] = [];
+  let cursor: string | undefined;
+  do {
+    const params = new URLSearchParams({ repo: DID, collection, limit: '100' });
+    if (cursor) params.set('cursor', cursor);
+    const res = await fetch(`${PDS}/xrpc/com.atproto.repo.listRecords?${params}`);
+    if (!res.ok) {
+      console.error(`Failed to fetch ${collection}: ${res.status}`);
+      return [];
+    }
+    const data = await res.json();
+    records.push(...(data.records ?? []));
+    cursor = data.cursor;
+  } while (cursor);
+  return records;
+}
+
+function convertRecord(r: any, collection: OldCollection): Record<string, any> {
+  const v = r.value;
+  const fragmentType = TYPE_MAP[collection];
+  const rkey = r.uri.split('/').pop()!;
+
+  const doc: Record<string, any> = {
+    $type: 'site.standard.document',
+    site: PUBLICATION_URI,
+    path: `/f/${v.fragmentId}`,
+    title: v.title || 'Untitled',
+    publishedAt: v.createdAt,
+    fragmentId: v.fragmentId,
+    fragmentType,
+  };
+
+  // Content field mapping
+  if (collection === 'rip.nate.link') {
+    doc.textContent = v.comment || undefined;
+    doc.externalUrl = v.url;
+  } else {
+    doc.textContent = v.content || undefined;
+  }
+
+  // Images
+  if (v.images && v.images.length > 0) {
+    doc.images = v.images;
+    doc.coverImage = v.images[0];
+  }
+
+  return doc;
+}
+
+async function main() {
+  console.log('=== Migrate to Standard.site ===\n');
+  console.log(`Mode: ${DRY_RUN ? 'DRY RUN' : 'LIVE'}${DELETE_OLD ? ' + DELETE OLD' : ''}\n`);
+
+  // Fetch all old records
+  const allOldRecords: { collection: OldCollection; record: any }[] = [];
+
+  for (const collection of OLD_COLLECTIONS) {
+    const records = await listRecords(collection);
+    console.log(`Found ${records.length} ${collection} records`);
+    for (const record of records) {
+      allOldRecords.push({ collection, record });
+    }
+  }
+
+  console.log(`\nTotal: ${allOldRecords.length} records to migrate\n`);
+
+  if (allOldRecords.length === 0) {
+    console.log('Nothing to migrate.');
+    return;
+  }
+
+  // Sort by fragmentId
+  allOldRecords.sort((a, b) => (a.record.value.fragmentId || 0) - (b.record.value.fragmentId || 0));
+
+  // Preview
+  console.log('Records to migrate:');
+  for (const { collection, record } of allOldRecords) {
+    const v = record.value;
+    const rkey = record.uri.split('/').pop();
+    console.log(`  #${String(v.fragmentId).padStart(2)} ${TYPE_MAP[collection].padEnd(4)} ${rkey} "${v.title || v.url || '(untitled)'}"`);
+  }
+
+  if (DRY_RUN) {
+    console.log('\n--dry-run: not uploading');
+    return;
+  }
+
+  // Login and migrate
+  const agent = new AtpAgent({ service: 'https://bsky.social' });
+  await agent.login({ identifier: HANDLE, password: PASSWORD! });
+  console.log(`\nLogged in as ${HANDLE}\n`);
+
+  const created: string[] = [];
+  const errors: string[] = [];
+
+  for (const { collection, record } of allOldRecords) {
+    const v = record.value;
+    const oldRkey = record.uri.split('/').pop()!;
+
+    try {
+      const newDoc = convertRecord(record, collection);
+
+      const res = await agent.com.atproto.repo.createRecord({
+        repo: agent.session!.did,
+        collection: 'site.standard.document',
+        record: newDoc,
+      });
+
+      const newRkey = res.data.uri.split('/').pop();
+      console.log(`✓ #${v.fragmentId} ${TYPE_MAP[collection]} → ${newRkey}`);
+      created.push(record.uri);
+
+      // Small delay to avoid rate limits
+      await new Promise(r => setTimeout(r, 100));
+    } catch (e: any) {
+      console.error(`✗ #${v.fragmentId} ${TYPE_MAP[collection]}: ${e.message}`);
+      errors.push(record.uri);
+    }
+  }
+
+  console.log(`\nMigrated: ${created.length}/${allOldRecords.length}`);
+  if (errors.length > 0) {
+    console.log(`Errors: ${errors.length}`);
+  }
+
+  // Delete old records if requested
+  if (DELETE_OLD && created.length > 0) {
+    console.log('\nDeleting old records...');
+    for (const { collection, record } of allOldRecords) {
+      if (!created.includes(record.uri)) continue;
+
+      const rkey = record.uri.split('/').pop()!;
+      try {
+        await agent.com.atproto.repo.deleteRecord({
+          repo: agent.session!.did,
+          collection,
+          rkey,
+        });
+        console.log(`  deleted ${collection}/${rkey}`);
+        await new Promise(r => setTimeout(r, 50));
+      } catch (e: any) {
+        console.error(`  failed to delete ${collection}/${rkey}: ${e.message}`);
+      }
+    }
+  }
+
+  console.log('\nDone.');
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/upload-link.ts
+++ b/scripts/upload-link.ts
@@ -6,9 +6,12 @@
  */
 import { AtpAgent } from '@atproto/api';
 
+const DID = 'did:plc:5dnwnjydruv7wmbi33xchkr6';
 const HANDLE = process.env.ATP_HANDLE || 'nate.rip';
 const PASSWORD = process.env.ATP_PASSWORD;
 if (!PASSWORD) { console.error('Set ATP_PASSWORD env var'); process.exit(1); }
+
+const PUBLICATION_URI = `at://${DID}/site.standard.publication/self`;
 
 const [,, url, idStr, titleArg, comment] = process.argv;
 if (!url || !idStr) {
@@ -37,14 +40,17 @@ await agent.login({ identifier: HANDLE, password: PASSWORD });
 
 await agent.com.atproto.repo.createRecord({
   repo: agent.session!.did,
-  collection: 'rip.nate.link',
+  collection: 'site.standard.document',
   record: {
-    $type: 'rip.nate.link',
-    fragmentId,
-    url,
+    $type: 'site.standard.document',
+    site: PUBLICATION_URI,
+    path: `/f/${fragmentId}`,
     title,
-    comment: comment || undefined,
-    createdAt: new Date().toISOString(),
+    textContent: comment || undefined,
+    publishedAt: new Date().toISOString(),
+    fragmentId,
+    fragmentType: 'link',
+    externalUrl: url,
   },
 });
 

--- a/scripts/upload-post.ts
+++ b/scripts/upload-post.ts
@@ -14,6 +14,8 @@ const DID = 'did:plc:5dnwnjydruv7wmbi33xchkr6';
 const HANDLE = process.env.ATP_HANDLE || 'nate.rip';
 const PASSWORD = process.env.ATP_PASSWORD;
 
+const PUBLICATION_URI = `at://${DID}/site.standard.publication/self`;
+
 const rawArgs = process.argv.slice(2);
 const DRY_RUN = rawArgs.includes('--dry-run');
 const dateIdx = rawArgs.indexOf('--date');
@@ -92,20 +94,24 @@ async function main() {
   }
 
   const record: Record<string, any> = {
-    $type: 'rip.nate.post',
-    fragmentId,
+    $type: 'site.standard.document',
+    site: PUBLICATION_URI,
+    path: `/f/${fragmentId}`,
     title,
-    content,
-    createdAt: dateOverride ? new Date(dateOverride).toISOString() : new Date().toISOString(),
+    textContent: content,
+    publishedAt: dateOverride ? new Date(dateOverride).toISOString() : new Date().toISOString(),
+    fragmentId,
+    fragmentType: 'post',
   };
 
   if (blobs.length > 0) {
     record.images = blobs;
+    record.coverImage = blobs[0];
   }
 
   const res = await agent.com.atproto.repo.createRecord({
     repo: agent.session!.did,
-    collection: 'rip.nate.post',
+    collection: 'site.standard.document',
     record,
   });
 

--- a/scripts/upload-post.ts
+++ b/scripts/upload-post.ts
@@ -9,6 +9,7 @@
 import { AtpAgent } from '@atproto/api';
 import { readFileSync, existsSync } from 'fs';
 import { resolve, dirname, extname, basename } from 'path';
+import { stripMarkdown, markdownContent } from './lib/markdown.js';
 
 const DID = 'did:plc:5dnwnjydruv7wmbi33xchkr6';
 const HANDLE = process.env.ATP_HANDLE || 'nate.rip';
@@ -39,15 +40,15 @@ function blobUrl(did: string, cid: string): string {
 }
 
 const fragmentId = parseInt(idStr, 10);
-let content = readFileSync(resolve(file), 'utf-8');
-const title = titleOverride || content.split('\n')[0].replace(/^#\s*/, '').trim() || 'Untitled';
+let markdownText = readFileSync(resolve(file), 'utf-8');
+const title = titleOverride || markdownText.split('\n')[0].replace(/^#\s*/, '').trim() || 'Untitled';
 const mdDir = dirname(resolve(file));
 
 // Find all markdown image references: ![alt](path)
 const IMG_RE = /!\[([^\]]*)\]\(([^)]+)\)/g;
 const imageRefs: { match: string; alt: string; path: string; absPath: string }[] = [];
 
-for (const m of content.matchAll(IMG_RE)) {
+for (const m of markdownText.matchAll(IMG_RE)) {
   const imgPath = m[2];
   // Skip URLs (already absolute)
   if (imgPath.startsWith('http://') || imgPath.startsWith('https://')) continue;
@@ -89,7 +90,7 @@ async function main() {
     const blob = data.blob;
     const cid = blob.ref?.$link ?? blob.ref?.toString?.() ?? String(blob.ref);
     const url = blobUrl(DID, cid);
-    content = content.replace(ref.match, `![${ref.alt}](${url})`);
+    markdownText = markdownText.replace(ref.match, `![${ref.alt}](${url})`);
     console.log(`  blob: ${basename(ref.absPath)} → ${cid.slice(0, 12)}...`);
   }
 
@@ -98,7 +99,8 @@ async function main() {
     site: PUBLICATION_URI,
     path: `/f/${fragmentId}`,
     title,
-    textContent: content,
+    content: markdownContent(markdownText),
+    textContent: stripMarkdown(markdownText),
     publishedAt: dateOverride ? new Date(dateOverride).toISOString() : new Date().toISOString(),
     fragmentId,
     fragmentType: 'post',

--- a/scripts/upload-publication.ts
+++ b/scripts/upload-publication.ts
@@ -20,6 +20,14 @@ async function main() {
     url: 'https://nate.rip',
     name: 'nate.rip',
     description: 'Fragments of thought, photos, lists, and links.',
+    basicTheme: {
+      $type: 'site.standard.theme.basic',
+      // Dark theme colors from theme.css
+      background: { $type: 'site.standard.theme.color#rgb', r: 23, g: 28, b: 43 },    // #171c2b
+      foreground: { $type: 'site.standard.theme.color#rgb', r: 184, g: 191, b: 207 }, // #b8bfcf
+      accent: { $type: 'site.standard.theme.color#rgb', r: 94, g: 196, b: 212 },      // #5ec4d4
+      accentForeground: { $type: 'site.standard.theme.color#rgb', r: 23, g: 28, b: 43 }, // #171c2b (dark on bright accent)
+    },
     preferences: {
       showInDiscover: true,
     },

--- a/scripts/upload-publication.ts
+++ b/scripts/upload-publication.ts
@@ -1,0 +1,42 @@
+/**
+ * Create the site.standard.publication record for nate.rip
+ * Usage: ATP_PASSWORD=... npx tsx scripts/upload-publication.ts
+ */
+import { AtpAgent } from '@atproto/api';
+
+const DID = 'did:plc:5dnwnjydruv7wmbi33xchkr6';
+const HANDLE = process.env.ATP_HANDLE || 'nate.rip';
+const PASSWORD = process.env.ATP_PASSWORD;
+if (!PASSWORD) { console.error('Set ATP_PASSWORD env var'); process.exit(1); }
+
+const RKEY = 'self'; // singleton publication record
+
+async function main() {
+  const agent = new AtpAgent({ service: 'https://bsky.social' });
+  await agent.login({ identifier: HANDLE, password: PASSWORD });
+
+  const record = {
+    $type: 'site.standard.publication',
+    url: 'https://nate.rip',
+    name: 'nate.rip',
+    description: 'Fragments of thought, photos, lists, and links.',
+    preferences: {
+      showInDiscover: true,
+    },
+  };
+
+  const res = await agent.com.atproto.repo.putRecord({
+    repo: agent.session!.did,
+    collection: 'site.standard.publication',
+    rkey: RKEY,
+    record,
+  });
+
+  console.log('Publication created:');
+  console.log(`  URI: ${res.data.uri}`);
+  console.log(`  CID: ${res.data.cid}`);
+  console.log(`\nVerification endpoint should return:`);
+  console.log(`  at://${DID}/site.standard.publication/${RKEY}`);
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,6 +1,6 @@
 ---
-interface Props { title?: string; wide?: boolean; }
-const { title, wide } = Astro.props;
+interface Props { title?: string; wide?: boolean; atUri?: string; }
+const { title, wide, atUri } = Astro.props;
 const pageTitle = title ? `${title} · nate.rip` : 'nate.rip';
 import '../styles/theme.css';
 ---
@@ -10,6 +10,7 @@ import '../styles/theme.css';
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{pageTitle}</title>
+  {atUri && <link rel="site.standard.document" href={atUri} />}
 </head>
 <body class:list={[wide && 'wide']}>
   <slot />

--- a/src/lib/atproto.ts
+++ b/src/lib/atproto.ts
@@ -27,13 +27,18 @@ async function listRecords(collection: string): Promise<any[]> {
 function mapRecord(r: any): Fragment {
   const v = r.value;
   const type: FragmentType = v.fragmentType || 'post';
+
+  // Extract markdown from content union (structured) or fall back to textContent
+  // content is { $type: "rip.nate.content.markdown", text: "..." }
+  const markdown = v.content?.text ?? v.textContent;
+
   return {
     id: v.fragmentId,
     type,
     rkey: r.uri.split('/').pop()!,
     atUri: r.uri,
     title: v.title || '',
-    content: v.textContent,
+    content: markdown,
     url: v.externalUrl,
     images: v.images?.map((img: any) => ({
       cid: img.ref?.$link || img.ref,

--- a/src/lib/atproto.ts
+++ b/src/lib/atproto.ts
@@ -33,13 +33,13 @@ function mapRecord(r: any): Fragment {
     rkey: r.uri.split('/').pop()!,
     atUri: r.uri,
     title: v.title || '',
-    content: v.textContent || v.content,
+    content: v.textContent,
     url: v.externalUrl,
     images: v.images?.map((img: any) => ({
       cid: img.ref?.$link || img.ref,
       mimeType: img.mimeType,
     })),
-    createdAt: v.publishedAt || v.createdAt,
+    createdAt: v.publishedAt,
   };
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,6 +4,7 @@ export interface Fragment {
   id: number;
   type: FragmentType;
   rkey: string;
+  atUri: string;
   title: string;
   content?: string;
   url?: string;

--- a/src/pages/.well-known/site.standard.publication.ts
+++ b/src/pages/.well-known/site.standard.publication.ts
@@ -1,0 +1,11 @@
+import type { APIRoute } from 'astro';
+
+const DID = 'did:plc:5dnwnjydruv7wmbi33xchkr6';
+const PUBLICATION_RKEY = 'self';
+
+export const GET: APIRoute = () => {
+  const atUri = `at://${DID}/site.standard.publication/${PUBLICATION_RKEY}`;
+  return new Response(atUri, {
+    headers: { 'Content-Type': 'text/plain' },
+  });
+};

--- a/src/pages/f/[id].astro
+++ b/src/pages/f/[id].astro
@@ -46,7 +46,7 @@ const typeAccent: Record<string, string> = {
 const accent = typeAccent[fragment.type] || 'var(--accent)';
 const date = new Date(fragment.createdAt).toISOString().slice(0, 10);
 ---
-<Base title={fragment.title} wide>
+<Base title={fragment.title} wide atUri={fragment.atUri}>
   <div class="detail-page" style={`--type-accent: ${accent}`}>
 
     <!-- === Chrome bar header === -->


### PR DESCRIPTION
Migrate the nate.rip application from the old rip.nate.* collections to the new site.standard schema for improved consistency and maintainability.

**Lexicon Changes**
- Added `site.standard.document` lexicon for generic document records with fragmentType enum (post/shot/list/link)
- Added `site.standard.publication` lexicon for publication metadata

**Scripts**
- Added `upload-publication.ts` to create publication singleton records
- Added `migrate-to-standard.ts` to convert existing records from old schema to new schema
- Updated `upload-link.ts`, `upload-post.ts`, and `upload.ts` to target site.standard.document collection with new field mappings (content→textContent, createdAt→publishedAt, url→externalUrl)

**Frontend Updates**
- Simplified `lib/atproto.ts` to fetch from a single COLLECTION_DOCUMENT with automatic fragmentType detection
- Updated `lib/types.ts` to include atUri field on Fragment type
- Updated `pages/f/[id].astro` to pass atUri to Base layout
- Updated `layouts/Base.astro` to add atUri prop and rel="site.standard.document" link header

**Dependencies**
- Removed ~8 "peer" flags from package-lock.json (dependencies no longer peer-only)
- Removed ~25 "dev" flags from esbuild platform-specific packages

> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/iamnbutler/iamnbutler.github.io/01KJ3GFPMC45XAVAXPP42BP3WY)